### PR TITLE
Misc updates

### DIFF
--- a/packages/stylesheet-docs/package-lock.json
+++ b/packages/stylesheet-docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jrgermain/stylesheet-docs",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jrgermain/stylesheet-docs",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "dependencies": {
         "@astrojs/check": "^0.9.4",
         "@fontsource-variable/lexend": "^5.0.18",

--- a/packages/stylesheet-docs/package.json
+++ b/packages/stylesheet-docs/package.json
@@ -2,7 +2,7 @@
   "name": "@jrgermain/stylesheet-docs",
   "private": true,
   "type": "module",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",

--- a/packages/stylesheet-docs/src/layouts/Layout.astro
+++ b/packages/stylesheet-docs/src/layouts/Layout.astro
@@ -121,18 +121,20 @@ const navSections = [
     </header>
     <div class="app-body">
       <nav class="app-sidebar">
-        {
-          navSections.map((section) => (
-            <section class="app-sidebar-section">
-              <h1 class="app-sidebar-heading">{section.heading}</h1>
-              {section.links.map((link) => (
-                <NavLink href={`/${toLink(section.heading)}/${toLink(link)}`}>
-                  {link}
-                </NavLink>
-              ))}
-            </section>
-          ))
-        }
+        <div class="app-sidebar-content">
+          {
+            navSections.map((section) => (
+              <section class="app-sidebar-section">
+                <h1 class="app-sidebar-heading">{section.heading}</h1>
+                {section.links.map((link) => (
+                  <NavLink href={`/${toLink(section.heading)}/${toLink(link)}`}>
+                    {link}
+                  </NavLink>
+                ))}
+              </section>
+            ))
+          }
+        </div>
       </nav>
       <main id="main-content" class="app-content">
         <slot />

--- a/packages/stylesheet-docs/src/layouts/Layout.astro
+++ b/packages/stylesheet-docs/src/layouts/Layout.astro
@@ -157,7 +157,6 @@ const navSections = [
 <style>
   .title {
     margin: auto;
-    margin-inline-start: 0;
     font-family: var(--font-family-mono);
     font-size: 1.1rem;
   }

--- a/packages/stylesheet-docs/src/pages/components/alert.astro
+++ b/packages/stylesheet-docs/src/pages/components/alert.astro
@@ -47,4 +47,33 @@ const exampleCode = `
       <p>The tip of a shoelace is called an aglet.</p>
     </div>
   </ComponentOption>
+  <ComponentOption name="Banner">
+    <p slot="details">
+      An alert can be used as a <strong>banner</strong> by adding the class <code
+        >banner</code
+      >. This is intended to be used for site-wide messages and should be placed
+      at the top of the page. You can add a button with the class <code
+        >dismiss</code
+      > to allow users to close the banner.
+    </p>
+    <div slot="examples">
+      <button
+        class="primary button"
+        onclick="document.querySelector('.app').prepend(document.querySelector('#banner-template').content.firstElementChild.cloneNode(true)); window.scrollTo({ top: 0, behavior: 'smooth' });"
+        >Add Site-wide Alert</button
+      >
+      <template id="banner-template">
+        <div class="alert banner info">
+          <p>
+            You're viewing the documentation for v2. To see documentation for
+            v1, click <a>here</a>.
+          </p>
+          <button
+            class="dismiss button"
+            title="Dismiss"
+            onclick="document.querySelector('.alert.banner').remove()"></button>
+        </div>
+      </template>
+    </div>
+  </ComponentOption>
 </ComponentDocs>

--- a/packages/stylesheet-docs/src/pages/components/button.astro
+++ b/packages/stylesheet-docs/src/pages/components/button.astro
@@ -107,7 +107,7 @@ const exampleCode = `
       be combined with a variant, size, or other modifiers described here.
     </p>
     <Fragment slot="examples">
-      <button class="icon">
+      <button class="icon button">
         <svg
           width="1.5em"
           height="1.5em"
@@ -124,7 +124,7 @@ const exampleCode = `
             stroke-linejoin="round"></path>
         </svg>
       </button>
-      <button class="red primary icon">
+      <button class="red primary icon button">
         <svg
           width="1.5em"
           height="1.5em"
@@ -141,7 +141,7 @@ const exampleCode = `
             stroke-linejoin="round"></path>
         </svg>
       </button>
-      <button class="subtle icon">
+      <button class="subtle icon button">
         <svg
           width="1.5em"
           height="1.5em"
@@ -180,15 +180,15 @@ const exampleCode = `
       </ul>
     </Fragment>
     <Fragment slot="examples">
-      <button class="primary red">Red</button>
-      <button class="primary orange">Orange</button>
-      <button class="primary yellow">Yellow</button>
-      <button class="primary green">Green</button>
-      <button class="primary sky">Sky</button>
-      <button class="primary blue">Blue</button>
-      <button class="primary purple">Purple</button>
-      <button class="primary magenta">Magenta</button>
-      <button class="primary gray">Gray</button>
+      <button class="button primary red">Red</button>
+      <button class="button primary orange">Orange</button>
+      <button class="button primary yellow">Yellow</button>
+      <button class="button primary green">Green</button>
+      <button class="button primary sky">Sky</button>
+      <button class="button primary blue">Blue</button>
+      <button class="button primary purple">Purple</button>
+      <button class="button primary magenta">Magenta</button>
+      <button class="button primary gray">Gray</button>
     </Fragment>
   </ComponentOption>
 </ComponentDocs>

--- a/packages/stylesheet-docs/src/pages/components/button.astro
+++ b/packages/stylesheet-docs/src/pages/components/button.astro
@@ -4,7 +4,7 @@ import ComponentOption from "../../components/ComponentOption.astro";
 
 const exampleCode = `
 <!-- Buttons are styled automatically -->
-<button>I'm a button</button>
+<button class="button">I'm a button</button>
 
 <!-- Other elements are styled as buttons with class "button" -->
 <a href="#" class="button">I'm a button too</a>
@@ -27,9 +27,9 @@ const exampleCode = `
       </p>
     </Fragment>
     <Fragment slot="examples">
-      <button class="primary">Primary</button>
-      <button class="secondary">Secondary</button>
-      <button class="subtle">Subtle</button>
+      <button class="primary button">Primary</button>
+      <button class="secondary button">Secondary</button>
+      <button class="subtle button">Subtle</button>
     </Fragment>
   </ComponentOption>
   <ComponentOption name="Size">
@@ -51,9 +51,9 @@ const exampleCode = `
       </p>
     </Fragment>
     <Fragment slot="examples">
-      <button class="small">Small</button>
-      <button class="medium">Medium</button>
-      <button class="large">Large</button>
+      <button class="small button">Small</button>
+      <button class="medium button">Medium</button>
+      <button class="large button">Large</button>
     </Fragment>
   </ComponentOption>
   <ComponentOption name="Disabled">
@@ -73,9 +73,9 @@ const exampleCode = `
       </p>
     </Fragment>
     <Fragment slot="examples">
-      <button disabled>Disabled attribute</button>
-      <button class="disabled">Disabled class</button>
-      <button aria-disabled="true">aria-disabled</button>
+      <button disabled class="button">Disabled attribute</button>
+      <button class="disabled button">Disabled class</button>
+      <button aria-disabled="true" class="button">aria-disabled</button>
     </Fragment>
   </ComponentOption>
   <ComponentOption name="Loading">
@@ -85,8 +85,8 @@ const exampleCode = `
       required.
     </p>
     <Fragment slot="examples">
-      <button disabled class="loading">Disabled and loading</button>
-      <button class="loading">Just loading</button>
+      <button disabled class="loading button">Disabled and loading</button>
+      <button class="loading button">Just loading</button>
     </Fragment>
   </ComponentOption>
   <ComponentOption name="Link">

--- a/packages/stylesheet-docs/src/pages/components/dialog-and-drawer.astro
+++ b/packages/stylesheet-docs/src/pages/components/dialog-and-drawer.astro
@@ -21,7 +21,7 @@ const exampleCode = `
     <button class="primary red button" onclick="$dialog.close()">
       Discard Changes
     </button>
-    <button autofocus class="button" onclick="$dialog.close()">
+    <button class="button" onclick="$dialog.close()">
       Keep Editing
     </button>
   </div>
@@ -153,7 +153,7 @@ const exampleCode = `
             </label>
             <label class="field">
               Nickname
-              <input autofocus value="Personal Savings" />
+              <input value="Personal Savings" />
             </label>
             <hr />
             <div class="warning alert">

--- a/packages/stylesheet-docs/src/pages/components/dialog-and-drawer.astro
+++ b/packages/stylesheet-docs/src/pages/components/dialog-and-drawer.astro
@@ -5,23 +5,23 @@ import ComponentOption from "../../components/ComponentOption.astro";
 const exampleCode = `
 <!-- For this example, we've defined a global variable '$dialog' pointing to the dialog element. -->
 
-<button onclick="$dialog.showModal()">
+<button class="button" onclick="$dialog.showModal()">
   Open Dialog
 </button>
 
 <dialog id="dialog1">
   <header class="dialog-header">
     <h1>Leave Without Saving?</h1>
-    <button class="close" onclick="$dialog.close()"></button>
+    <button class="close button" onclick="$dialog.close()"></button>
   </header>
   <div class="dialog-body">
     <p>You have unsaved edits. What would you like to do?</p>
   </div>
   <div class="dialog-footer">
-    <button class="primary red" onclick="$dialog.close()">
+    <button class="primary red button" onclick="$dialog.close()">
       Discard Changes
     </button>
-    <button autofocus onclick="$dialog.close()">
+    <button autofocus class="button" onclick="$dialog.close()">
       Keep Editing
     </button>
   </div>
@@ -61,14 +61,15 @@ const exampleCode = `
               <option value="large">Large</option>
             </select>
           </label>
-          <button onclick="$dialog2.showModal()"> Open Dialog</button>
+          <button class="button" onclick="$dialog2.showModal()">
+            Open Dialog</button
+          >
         </div>
 
         <dialog id="dialog2" x-bind:class="size">
           <header class="dialog-header">
             <h1>This is a <span x-text="size"></span> dialog</h1>
-            <button class="small subtle icon close" onclick="$dialog2.close()"
-            ></button>
+            <button class="close button" onclick="$dialog2.close()"></button>
           </header>
           <div class="dialog-body">
             <p>
@@ -134,14 +135,15 @@ const exampleCode = `
               <option value="large">Large</option>
             </select>
           </label>
-          <button onclick="$drawer.showModal()">Open Drawer</button>
+          <button class="button" onclick="$drawer.showModal()"
+            >Open Drawer</button
+          >
         </div>
 
         <dialog id="drawer1" x-bind:class="'drawer ' + side + ' ' + size">
           <header class="dialog-header">
             <h1>Account Settings</h1>
-            <button class="small subtle icon close" onclick="$drawer.close()"
-            ></button>
+            <button class="close button" onclick="$drawer.close()"></button>
           </header>
 
           <div class="dialog-body dense vertical stack">

--- a/packages/stylesheet-docs/src/pages/components/form-field.astro
+++ b/packages/stylesheet-docs/src/pages/components/form-field.astro
@@ -234,4 +234,45 @@ const exampleCode = `
       </label>
     </Fragment>
   </ComponentOption>
+  <ComponentOption name="Fieldset">
+    <p slot="details">
+      You can use a <code>fieldset</code> element with a corresponding <code
+        >legend</code
+      > to define a group of related input fields.
+    </p>
+    <Fragment slot="examples">
+      <fieldset>
+        <legend>Deposit Amount</legend>
+        <label class="field">
+          Amount
+          <input type="number" step="0.01" />
+        </label>
+        <label class="field">
+          Currency
+          <select>
+            <option>USD</option>
+            <option>EUR</option>
+            <option>CHF</option>
+          </select>
+        </label>
+      </fieldset>
+      <fieldset>
+        <legend>Console</legend>
+        <div class="densest vertical stack">
+          <label>
+            <input type="radio" name="radio" />
+            Nintendo Switch
+          </label>
+          <label>
+            <input type="radio" name="radio" />
+            Xbox
+          </label>
+          <label>
+            <input type="radio" name="radio" />
+            PlayStation
+          </label>
+        </div>
+      </fieldset>
+    </Fragment>
+  </ComponentOption>
 </ComponentDocs>

--- a/packages/stylesheet-docs/src/pages/components/layout.astro
+++ b/packages/stylesheet-docs/src/pages/components/layout.astro
@@ -4,9 +4,9 @@ import ComponentOption from "../../components/ComponentOption.astro";
 
 const exampleCode = `
 <div class="dense horizontal stack">
-  <button>1</button>
-  <button>2</button>
-  <button>3</button>
+  <button class="button">1</button>
+  <button class="button">2</button>
+  <button class="button">3</button>
 </div>
 `;
 ---

--- a/packages/stylesheet/package-lock.json
+++ b/packages/stylesheet/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jrgermain/stylesheet",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jrgermain/stylesheet",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
         "@csstools/postcss-sass": "^5.0.1",

--- a/packages/stylesheet/package.json
+++ b/packages/stylesheet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jrgermain/stylesheet",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "A stylesheet for apps I build",
   "homepage": "https://stylesheet.jrgermain.dev",
   "author": {

--- a/packages/stylesheet/src/styles/components/_alert.scss
+++ b/packages/stylesheet/src/styles/components/_alert.scss
@@ -68,6 +68,9 @@
     --alert-bg-color: var(--color-red-9);
     --alert-border-start-color: var(--color-red-5);
     --alert-border-end-color: var(--color-red-6);
+    --alert-dismiss-icon-color: var(--color-red-4);
+    --alert-dismiss-hover-bg: var(--color-red-extra-transparent);
+    --alert-dismiss-focus-bg: var(--color-red-transparent);
     --alert-icon: #{utils.svg-to-data-url(
         '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="64" d="M368 368L144 144M368 144L144 368"/></svg>'
       )};
@@ -77,6 +80,9 @@
     --alert-bg-color: var(--color-yellow-9);
     --alert-border-start-color: var(--color-yellow-5);
     --alert-border-end-color: var(--color-yellow-6);
+    --alert-dismiss-icon-color: var(--color-yellow-4);
+    --alert-dismiss-hover-bg: var(--color-yellow-extra-transparent);
+    --alert-dismiss-focus-bg: var(--color-yellow-transparent);
     --alert-icon: #{utils.svg-to-data-url(
         '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path d="M256 80c-8.66 0-16.58 7.36-16 16l8 216a8 8 0 008 8h0a8 8 0 008-8l8-216c.58-8.64-7.34-16-16-16z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="64"/><circle cx="256" cy="436" r="24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="48"/></svg>'
       )};
@@ -86,6 +92,9 @@
     --alert-bg-color: var(--color-green-9);
     --alert-border-start-color: var(--color-green-5);
     --alert-border-end-color: var(--color-green-6);
+    --alert-dismiss-icon-color: var(--color-green-4);
+    --alert-dismiss-hover-bg: var(--color-green-extra-transparent);
+    --alert-dismiss-focus-bg: var(--color-green-transparent);
     --alert-icon: #{utils.svg-to-data-url(
         '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="64" d="M416 128L192 384l-96-96"/></svg>'
       )};
@@ -95,9 +104,66 @@
     --alert-bg-color: var(--color-sky-9);
     --alert-border-start-color: var(--color-sky-5);
     --alert-border-end-color: var(--color-sky-6);
+    --alert-dismiss-icon-color: var(--color-sky-4);
+    --alert-dismiss-hover-bg: var(--color-sky-extra-transparent);
+    --alert-dismiss-focus-bg: var(--color-sky-transparent);
     --alert-icon: #{utils.svg-to-data-url(
         '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="64" d="M196 220h64v172"/><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-miterlimit="10" stroke-width="64" d="M187 396h138"/><circle cx="253 " cy="118" r="44"/></svg>'
       )};
+  }
+
+  &.banner {
+    border-radius: 0;
+    border-width: var(--border-m) 0;
+    width: 100%;
+    padding: var(--space-xs);
+    padding-inline-start: calc(var(--space-xs) + 2em);
+
+    &:has(.button.dismiss) {
+      padding-inline-end: calc(var(--space-xs) + 2em);
+    }
+
+    &::before,
+    &::after {
+      inset-inline-start: calc(var(--space-xs) * 0.5);
+      margin: auto;
+      width: 2em;
+      height: 2em;
+    }
+
+    .button.dismiss {
+      --button-fg-color: var(--alert-dismiss-icon-color);
+      --button-bg-color: transparent;
+      --button-border-color: transparent;
+      --button-hover-bg-color: var(--alert-dismiss-hover-bg);
+      --button-focus-ring-color: transparent;
+      --button-shadow: none;
+
+      font-size: 0.75rem;
+      position: absolute;
+      inset-block: 0;
+      inset-inline-end: var(--space-3xs);
+      margin: auto;
+      width: 3em;
+      height: 3em;
+
+      &:is(:focus-visible, .focus) {
+        --button-bg-color: var(--alert-dismiss-focus-bg);
+        --button-hover-bg-color: transparent;
+      }
+
+      &::after {
+        content: "";
+        width: 1.8em;
+        height: 1.8em;
+        mask-image: #{utils.svg-to-data-url(
+            '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="32" d="M368 368L144 144M368 144L144 368"/></svg>'
+          )};
+        mask-size: contain;
+        mask-repeat: no-repeat;
+        background-color: currentcolor;
+      }
+    }
   }
 }
 

--- a/packages/stylesheet/src/styles/components/_app.scss
+++ b/packages/stylesheet/src/styles/components/_app.scss
@@ -3,8 +3,6 @@
 
 .app {
   --app-width: 110rem;
-  --app-header-height: clamp(50px, 3.5rem, 70px);
-  --app-sidebar-width: clamp(300px, 18rem, 400px);
 
   position: relative;
   width: 100%;
@@ -14,13 +12,15 @@
 }
 
 .app-header {
-  height: var(--app-header-height);
+  height: clamp(50px, 3.5rem, 70px);
   width: 100%;
   color: var(--color-brand-3);
   background-color: var(--color-body-alt);
   border-bottom: var(--border-l) solid var(--color-brand-transparent);
   box-shadow: var(--shadow-s);
   flex: none;
+  overflow: auto hidden;
+  scrollbar-width: thin;
 
   @media (prefers-color-scheme: dark) {
     color: var(--color-brand-2);
@@ -140,7 +140,7 @@
   transition:
     opacity 150ms ease,
     display 150ms allow-discrete;
-  width: var(--app-sidebar-width);
+  width: clamp(300px, 18rem, 400px);
   flex: none;
   opacity: 1;
   border-inline-end: var(--border-s) dashed var(--color-outline);

--- a/packages/stylesheet/src/styles/components/_app.scss
+++ b/packages/stylesheet/src/styles/components/_app.scss
@@ -7,11 +7,10 @@
   --app-sidebar-width: clamp(300px, 18rem, 400px);
 
   position: relative;
-  width: 100dvw;
-  height: 100dvh;
+  width: 100%;
+  min-height: 100svh;
   display: flex;
   flex-direction: column;
-  overflow: visible;
 }
 
 .app-header {
@@ -132,32 +131,27 @@
   width: 100%;
   max-width: var(--app-width);
   margin-inline: auto;
+  flex: none;
+  display: flex;
+  flex-direction: row;
 }
 
 .app-sidebar {
-  // TODO simplify
-  overflow: auto;
   transition:
     opacity 150ms ease,
     display 150ms allow-discrete;
   width: var(--app-sidebar-width);
-  position: absolute;
-  top: 0;
-  left: 0;
-  height: 100%;
-  z-index: 3;
+  flex: none;
   opacity: 1;
-  border-inline-end: var(--border-s) solid;
-  border-image: linear-gradient(
-      to bottom,
-      transparent 0%,
-      transparent 10%,
-      var(--color-outline) 10%,
-      var(--color-outline) 90%,
-      transparent 90%,
-      transparent 100%
-    )
-    80;
+  border-inline-end: var(--border-s) dashed var(--color-outline);
+}
+
+.app-sidebar-content {
+  position: sticky;
+  top: 0;
+  overflow: auto;
+  height: auto;
+  height: 100dvh;
 }
 
 .app-sidebar-section {
@@ -201,7 +195,7 @@
     color: var(--color-brand-1);
   }
 
-  &:is(.current, [aria-current="page"]) {
+  &:is([aria-current], .current) {
     color: var(--color-brand-4);
     font-weight: var(--font-weight-bold);
   }
@@ -294,40 +288,9 @@
 
 .app:has(.app-sidebar) {
   --app-width: 125rem;
-
-  overflow: hidden;
-
-  .app-header {
-    position: fixed;
-    top: 0;
-    left: 0;
-  }
-
-  .app-body {
-    position: fixed;
-    top: var(--app-header-height);
-    left: 0;
-    right: 0;
-    margin-inline: auto;
-    height: calc(100dvh - var(--app-header-height));
-  }
-
-  .app-content {
-    overflow: auto;
-    position: absolute;
-    top: 0;
-    left: var(--app-sidebar-width);
-    width: calc(100% - var(--app-sidebar-width));
-    height: 100%;
-  }
 }
 
 @media (width < 55rem) {
-  .app-content {
-    left: 0 !important;
-    width: 100dvw !important;
-  }
-
   .app-sidebar {
     width: 100dvw;
     opacity: 1;

--- a/packages/stylesheet/src/styles/components/_app.scss
+++ b/packages/stylesheet/src/styles/components/_app.scss
@@ -45,7 +45,6 @@
   height: 100%;
   display: flex;
   align-items: center;
-  gap: var(--space-3xs);
 
   // If header only has 1 section, center it
   &:only-child {
@@ -55,6 +54,22 @@
   // Otherwise, align the first to the left and the rest to the right
   &:first-child {
     margin-inline-end: auto;
+  }
+
+  // The content of the first header item should be var(--space-body) from the
+  // left edge of the app. Since there is var(--space-body) padding in the
+  // header and var(--space-xs) padding in the header items, we just need to
+  // move it back by var(--space-xs).
+  &:first-child .app-header-item:first-child {
+    margin-inline-start: calc(-1 * var(--space-xs));
+  }
+
+  // The content of the last header item should be var(--space-body) from the
+  // right edge of the app. Since there is var(--space-body) padding in the
+  // header and var(--space-xs) padding in the header items, we just need to
+  // move it forward by var(--space-xs).
+  &:last-child .app-header-item:last-child {
+    margin-inline-end: calc(-1 * var(--space-xs));
   }
 
   // Put a spacer between consecutive right-aligned sections (3rd onward)
@@ -81,6 +96,7 @@
   align-items: center;
   position: relative;
   font-weight: var(--font-weight-semibold);
+  padding-inline: var(--space-xs);
 
   &:focus-visible {
     outline-offset: calc(-1 * var(--border-m));

--- a/packages/stylesheet/src/styles/components/_button.scss
+++ b/packages/stylesheet/src/styles/components/_button.scss
@@ -1,10 +1,4 @@
-:is(
-    button,
-    .button,
-    input[type="button"],
-    input[type="submit"],
-    input[type="reset"]
-  ):not(.chip, .card, .chip .delete, .input-group .action) {
+.button {
   --button-shadow: var(--shadow-s);
   --button-hover-bg-color: var(--button-border-color);
 
@@ -118,7 +112,7 @@
   }
 
   // .secondary, default
-  &:not(.primary, .subtle, .close) {
+  &:not(.primary, .subtle, .close, .dismiss) {
     --button-fg-color: var(--color-body-text);
     --button-bg-color: var(--color-gray-9);
     --button-border-color: var(--color-gray-8);
@@ -141,7 +135,7 @@
     }
   }
 
-  &:is(.small, .close) {
+  &:is(.small, .close, .dismiss) {
     font-size: 0.8rem;
   }
 
@@ -149,7 +143,7 @@
     font-size: 1.2rem;
   }
 
-  &:is(.icon, .close) {
+  &:is(.icon, .close, .dismiss) {
     border-radius: var(--radius-full);
     min-width: 0;
     min-height: 0;
@@ -172,11 +166,12 @@
       padding: 0.5em;
     }
 
-    &.close {
+    &.close,
+    &.dismiss {
       padding: 0.3em;
     }
 
-    &:not(.subtle, .close) {
+    &:not(.subtle, .close, .dismiss) {
       &::before {
         content: unset;
       }

--- a/packages/stylesheet/src/styles/components/_chip.scss
+++ b/packages/stylesheet/src/styles/components/_chip.scss
@@ -102,7 +102,7 @@ $color-variants: (
     }
   }
 
-  :is(button, .button).delete {
+  .delete {
     outline: 0;
     margin-inline: var(--space-3xs) calc(-1 * var(--space-2xs));
     font-size: 0.6em;

--- a/packages/stylesheet/src/styles/components/_details.scss
+++ b/packages/stylesheet/src/styles/components/_details.scss
@@ -114,6 +114,7 @@ details {
     box-shadow: none;
     border: 0;
     padding-inline: var(--space-2xs);
+    background-color: transparent;
 
     summary {
       border-block-end: 0;

--- a/packages/stylesheet/src/styles/components/_dialog.scss
+++ b/packages/stylesheet/src/styles/components/_dialog.scss
@@ -211,7 +211,7 @@ dialog {
   flex-shrink: 0;
   display: flex;
   gap: var(--space-2xs);
-  justify-content: flex-end;
+  justify-content: flex-start;
   background-color: var(--color-body);
   border-block-start: var(--border-s) solid var(--color-outline);
   margin: 0;

--- a/packages/stylesheet/src/styles/components/_dialog.scss
+++ b/packages/stylesheet/src/styles/components/_dialog.scss
@@ -178,7 +178,7 @@ dialog {
     margin: 0;
   }
 
-  :is(button, .button).close {
+  .button.close {
     color: inherit;
     margin: -0.5rem;
     margin-inline-start: var(--space-3xs);
@@ -222,13 +222,7 @@ dialog {
     justify-content: stretch;
   }
 
-  :is(
-      button,
-      .button,
-      input[type="button"],
-      input[type="submit"],
-      input[type="reset"]
-    ):not(.small, .medium, .large) {
+  .button:not(.small, .medium, .large) {
     font-size: 0.9rem;
   }
 }

--- a/packages/stylesheet/src/styles/components/_field.scss
+++ b/packages/stylesheet/src/styles/components/_field.scss
@@ -287,11 +287,14 @@
 
 fieldset {
   border: var(--border-s) solid var(--color-outline);
-  border-radius: var(--radius-l);
+  border-radius: var(--radius-s);
+  background-color: var(--color-body);
+  color: var(--color-body-text);
 
   legend {
-    color: var(--color-body-text);
-    font-weight: var(--font-weight-semibold);
+    color: var(--color-brand-3);
+    font-family: var(--font-family-heading);
+    font-weight: var(--font-weight-bold);
   }
 }
 

--- a/packages/stylesheet/src/styles/components/_field.scss
+++ b/packages/stylesheet/src/styles/components/_field.scss
@@ -2,7 +2,7 @@
 
 .field {
   --field-gap: var(--space-2xs);
-  --field-padding: var(--space-2xs);
+  --field-padding: 0.5em;
   --field-radius: var(--radius-m);
 
   display: inline-flex;
@@ -19,7 +19,7 @@
   &.compact,
   :is(form, .form, fieldset).compact & {
     --field-gap: calc(0.9 * var(--space-2xs));
-    --field-padding: calc(0.75 * var(--space-2xs));
+    --field-padding: 0.33em;
     --field-radius: var(--radius-s);
 
     font-size: calc(0.9 * var(--font-size-m));
@@ -229,7 +229,7 @@
       color: var(--color-gray-3);
       background-color: var(--color-gray-9);
       border: var(--border-s) solid var(--color-outline);
-      padding: var(--space-3xs) var(--space-xs);
+      padding: var(--field-padding) calc(2 * var(--field-padding));
       align-items: center;
       justify-content: center;
       font-size: 0.9em;

--- a/packages/stylesheet/src/styles/components/_skeleton.scss
+++ b/packages/stylesheet/src/styles/components/_skeleton.scss
@@ -55,7 +55,7 @@
     content: ".";
   }
 
-  &:is(button, .button, .chip):empty {
+  &:is(.button, .chip):empty {
     min-inline-size: 5em;
   }
 

--- a/packages/stylesheet/src/styles/components/_text.scss
+++ b/packages/stylesheet/src/styles/components/_text.scss
@@ -1,6 +1,12 @@
 @use "../utils";
 @use "./layout";
 
+@mixin highlighted-text($color) {
+  background-color: var(--color-#{$color}-8);
+  color: var(--color-#{$color}-2);
+  print-color-adjust: exact;
+}
+
 %heading-any {
   font-family: var(--font-family-heading);
   margin-block: 0.75em 0.3em;
@@ -190,34 +196,31 @@ em,
   font-style: italic;
 }
 
-mark,
-.mark {
-  background-color: var(--color-yellow-8);
-  color: var(--color-yellow-1);
-  print-color-adjust: exact;
-
-  @media (prefers-color-scheme: dark) {
-    background-color: var(--color-yellow-7);
-  }
+::target-text {
+  @include highlighted-text("brand");
 }
 
-del,
-.del {
-  text-decoration-line: line-through;
-  text-decoration-skip-ink: none;
-  text-decoration-thickness: var(--border-s);
-  background-color: var(--color-red-8);
-  color: var(--color-red-1);
-  text-decoration-color: var(--color-body-text);
-  border-radius: 1px;
+mark,
+.mark {
+  @include highlighted-text("yellow");
 }
 
 ins,
 .ins {
-  text-decoration-line: none;
-  background-color: var(--color-green-8);
-  color: var(--color-green-1);
-  border-radius: 1px;
+  @include highlighted-text("green");
+
+  text-decoration-thickness: var(--border-s);
+  text-decoration-color: var(--color-body-text);
+}
+
+del,
+.del {
+  @include highlighted-text("red");
+
+  text-decoration-line: line-through;
+  text-decoration-skip-ink: none;
+  text-decoration-thickness: var(--border-s);
+  text-decoration-color: var(--color-body-text);
 }
 
 :is(abbr, .abbr)[title] {
@@ -253,12 +256,6 @@ sub,
 sup,
 .sup {
   inset-block-start: -0.5em;
-}
-
-::target-text {
-  background-color: var(--color-brand-8);
-  color: var(--color-brand-1);
-  print-color-adjust: exact;
 }
 
 /* Add a gap between consecutive block text elements */

--- a/packages/stylesheet/src/styles/components/_text.scss
+++ b/packages/stylesheet/src/styles/components/_text.scss
@@ -258,12 +258,6 @@ sup,
   inset-block-start: -0.5em;
 }
 
-::target-text {
-  background-color: var(--color-brand-8);
-  color: var(--color-brand-1);
-  print-color-adjust: exact;
-}
-
 /* Add a gap between consecutive block text elements */
 // prettier-ignore
 :is(p, .p, blockquote, .blockquote, pre, .pre, samp, .samp, .alert, details):not(.alert-title, .accordion details) +

--- a/packages/stylesheet/src/styles/components/_text.scss
+++ b/packages/stylesheet/src/styles/components/_text.scss
@@ -192,14 +192,12 @@ em,
 
 mark,
 .mark {
-  background-color: var(--color-yellow-9);
-  color: black;
-  padding: 0.1em 0.25em;
-  border-radius: var(--radius-s);
+  background-color: var(--color-yellow-8);
+  color: var(--color-yellow-1);
   print-color-adjust: exact;
 
   @media (prefers-color-scheme: dark) {
-    background-color: var(--color-yellow-2);
+    background-color: var(--color-yellow-7);
   }
 }
 
@@ -255,6 +253,12 @@ sub,
 sup,
 .sup {
   inset-block-start: -0.5em;
+}
+
+::target-text {
+  background-color: var(--color-brand-8);
+  color: var(--color-brand-1);
+  print-color-adjust: exact;
 }
 
 /* Add a gap between consecutive block text elements */


### PR DESCRIPTION
This PR includes updates to the following areas

- App Header is no longer fixed when the App Sidebar is present
- Subtle variant for `<details>` no longer has a background
- Style target text from URL
- Updated styles for `<fieldset>` element
- Change dialog action button alignment from flex-end to flex-start
- Tweaks to spacing, sizing, etc.

Breaking Changes
- Buttons now require the class "button" to get styled. This makes it easier to use `<button>` elements for other purposes, removing the need to revert all the styling or further complicate selectors.